### PR TITLE
Allow retry when some operations have been deleted

### DIFF
--- a/src/Actions/RetryBulkRequest.php
+++ b/src/Actions/RetryBulkRequest.php
@@ -27,9 +27,9 @@ class RetryBulkRequest implements RetriesBulkRequest
         foreach ($bulkRequest->request as $index => $request) {
 
             /** @var BulkOperation $operation */
-            $operation = $operations->where('operation_id', '=', $index)->firstOrFail();
+            $operation = $operations->where('operation_id', '=', $index)->first();
 
-            if ($onlyFailed && ! in_array($operation->status, OperationStatus::failedStatuses())) {
+            if ($operation === null || ($onlyFailed && ! in_array($operation->status, OperationStatus::failedStatuses()))) {
                 continue;
             }
 

--- a/src/Actions/RetryBulkRequest.php
+++ b/src/Actions/RetryBulkRequest.php
@@ -26,7 +26,7 @@ class RetryBulkRequest implements RetriesBulkRequest
 
         foreach ($bulkRequest->request as $index => $request) {
 
-            /** @var BulkOperation $operation */
+            /** @var ?BulkOperation $operation */
             $operation = $operations->where('operation_id', '=', $index)->first();
 
             if ($operation === null || ($onlyFailed && ! in_array($operation->status, OperationStatus::failedStatuses()))) {


### PR DESCRIPTION
We automatically clean up operations when they are completed but our retry action expected them all to exist which makes it impossible to retry requests when the successful operations have been deleted.